### PR TITLE
Issue 289 least upper bound nullable requires subtype

### DIFF
--- a/lang/lang/statics/type.stx
+++ b/lang/lang/statics/type.stx
@@ -231,7 +231,8 @@ rules // operations on types
   lubs maps lub(list(*), list(*)) = list(*)
   lub(NullType(), T) = makeNullable(T).
   lub(T, NullType()) = makeNullable(T).
-  lub(NullableType(T1), NullableType(T2)) = NullableType(lub(T1, T2)).
+  lub(NullableType(T1), T2) = makeNullable(lub(T1, T2)).
+  lub(T1, NullableType(T2)) = makeNullable(lub(T1, T2)).
   lub(EmptyListType(), ListType(T)) = ListType(T).
   lub(ListType(T), EmptyListType()) = ListType(T).
   lub(T1@DataType(_), T2@DataType(_)) =

--- a/lang/lang/test/expression.spt
+++ b/lang/lang/test/expression.spt
@@ -195,7 +195,7 @@ test ifelse true branch subtype with different type arguments [[ [[ val res: Gen
 test ifelse false branch subtype with different type arguments [[ [[ val res: Generic[_ <: Foo, Baar, _] = if (value == 0) generic2 else genericSub ]] ]] analysis succeeds run pie-ast-type on #1 to DataType(_)
 test ifelse branch type mismatch [[ [[ if (value == 0) "hello" else 10 ]] ]] analysis succeeds  run pie-ast-type on #1 to TopType()
 test ifelse branch type mismatch datatypes [[ [[ if (value == 0) bak else bok ]] ]] analysis succeeds  run pie-ast-type on #1 to TopType()
-test ifelse branch type mismatch nullable datatypes [[ [[ if (value == 0) foo? else bok? ]] ]] analysis succeeds  run pie-ast-type on #1 to NullableType(TopType())
+test ifelse branch type mismatch nullable datatypes [[ [[ if (value == 0) foo? else bok? ]] ]] analysis succeeds  run pie-ast-type on #1 to TopType()
 test ifelse with blocks [[ [[ if (value == 10) {"hello"} else {anotherFunc(); "world"} ]] ]] analysis succeeds run pie-ast-type on #1 to StrType()
 test ifelse error in any branch [[ if (value == 10) [[not_defined]] else "world" ]] error like "resolve" at #1
 test ifelse error in dead code [[ if (true) "hello" else [[not_defined]] ]] error like "resolve" at #1

--- a/lang/lang/test/expression/literals/list.spt
+++ b/lang/lang/test/expression/literals/list.spt
@@ -47,3 +47,6 @@ test list literal subtypes only
 test list literal nullable subtypes only
   [[ val list: Fruit?* = [banana?, apple?] ]]
   analysis succeeds
+test list literal mixed nullable subtypes
+  [[ val list: Fruit?* = [banana, apple?] ]]
+  analysis succeeds


### PR DESCRIPTION
Fixes a bug where the least upper bound of a nullable type with a non-nullable type requires a subtype relationship, otherwise the top type is returned.
As a minimal example, the type of `[apple, banana?]` is not `Fruit?*` as one would expect, but `TOP*`.
See MeAmAnUsername/pie#289 for more details.

This PR depends on #17