### PR TITLE
Allow top type for if-else expressions

### DIFF
--- a/lang/lang/statics/func_body.stx
+++ b/lang/lang/statics/func_body.stx
@@ -116,9 +116,7 @@ rules
     expectAssignableTo(s, exp_cond, BoolType(), ExpressionKind()) == s_if,
     typeOfExp(s_if, exp_true) == (_, ty_true),
     typeOfExp(s_if, exp_false) == (_, ty_false),
-    lub(ty_true, ty_false) == ty,
-    try { ty != TopType()               } | error $[Type mismatch: true branch ([ty_true]) and false branch ([ty_false]) combine to the top type],
-    try { ty != NullableType(TopType()) } | error $[Type mismatch: true branch ([ty_true]) and false branch ([ty_false]) combine to the top type].
+    lub(ty_true, ty_false) == ty.
 
   typeOfExpImpl(s1, ListComprehension(exp_map, binder, exp_list)) =
     (s1, ListType(ty_map))

--- a/lang/lang/test/expression.spt
+++ b/lang/lang/test/expression.spt
@@ -193,9 +193,9 @@ test ifelse branches equal with type arguments [[ [[ val res: Generic[Foo, Baar,
 test ifelse branches simple type equal with different type arguments [[ [[ val res: Generic[_ <: Foo, Baar, _] = if (value == 0) generic2 else generic1 ]] ]] analysis succeeds run pie-ast-type on #1 to DataType(_)
 test ifelse true branch subtype with different type arguments [[ [[ val res: Generic[_ <: Foo, Baar, _] = if (value == 0) genericSub else generic1 ]] ]] analysis succeeds run pie-ast-type on #1 to DataType(_)
 test ifelse false branch subtype with different type arguments [[ [[ val res: Generic[_ <: Foo, Baar, _] = if (value == 0) generic2 else genericSub ]] ]] analysis succeeds run pie-ast-type on #1 to DataType(_)
-test ifelse branch type mismatch [[ if (value == 0) "hello" else 10 ]] 1 error
-test ifelse branch type mismatch datatypes [[ if (value == 0) bak else bok ]] 1 error error like "Type mismatch"
-test ifelse branch type mismatch nullable datatypes [[ if (value == 0) foo? else bok? ]] 1 error error like "Type mismatch"
+test ifelse branch type mismatch [[ [[ if (value == 0) "hello" else 10 ]] ]] analysis succeeds  run pie-ast-type on #1 to TopType()
+test ifelse branch type mismatch datatypes [[ [[ if (value == 0) bak else bok ]] ]] analysis succeeds  run pie-ast-type on #1 to TopType()
+test ifelse branch type mismatch nullable datatypes [[ [[ if (value == 0) foo? else bok? ]] ]] analysis succeeds  run pie-ast-type on #1 to NullableType(TopType())
 test ifelse with blocks [[ [[ if (value == 10) {"hello"} else {anotherFunc(); "world"} ]] ]] analysis succeeds run pie-ast-type on #1 to StrType()
 test ifelse error in any branch [[ if (value == 10) [[not_defined]] else "world" ]] error like "resolve" at #1
 test ifelse error in dead code [[ if (true) "hello" else [[not_defined]] ]] error like "resolve" at #1


### PR DESCRIPTION
Original reason was that it is often unintended. However, it may still be intended sometimes. Even when it is unintended, trying to use the resulting value will then likely give an error instead. Additionally, if one of the branches has an error, it will often return an empty type, which then combines to the top type, which means the entire if-else expression gets an error,  which makes it hard to find the root cause.
For example, given `if (flag) getCount(names) else getCounWithoutNames()`, the entire if expression will be underlines, instead of only the misspelled function name `getCounWithoutNames`.

For details see MeAmAnUsername/pie#259